### PR TITLE
added an extra space optional keyword for engticks when using symbol

### DIFF
--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -51,7 +51,7 @@ _symlog_formatter(x) = x
     kind::Symbol = :number
     suffix::String = ""
     digits::Int = 0
-    space::Bool = false
+    space::Bool = true
 end
 
 EngTicks(kind; kwargs...) = EngTicks(; kind, kwargs...)


### PR DESCRIPTION
EngTicks adds a space between numbers and the "unit" symbol when as in `3000 k`. This PR adds a keyword option `space` for that space. The default is `space = true`, that is a space added by default as was the previous behavior. This can be removed by using `space = false` 